### PR TITLE
Added automated mode and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,41 @@ You need to supply three arguments:
 * *--out* - prefix for the output. For example, if you want an output file "/outfolder/out.prs" it would be "--out /outfolder/out".
 
 ### Running
+#### Standard mode
 Once you start, it will prompt you at the bottom of the screen to provide the information. You will need to:
 supply the names of the columns for beta and effect allele in the PGSCatalog data
 choose if your plink data are using rsid or chrom:pos as identifiers (more options and better alignment will be done in the future)
 supply the names of the columns for rsid OR chromosome+position in the PGSCatalog data
 make the final confirmation
+
+#### Automated mode
+Experienced users might want to run the tool from their code.  
+To make it possible the tool also accepts *--config* argument, which must point to a [YAML](https://yaml.org/spec/1.2/spec.html#id2761803) file, defining the following scalar variables:
+```yaml
+# first, define beta and effect allele columns:
+beta column: NAME OF THE BETA COLUMN
+effect allele column: NAME OF THE EFFECT ALLELE COLUMN
+# next, choose how to match your files -
+# using rsid [rsid] or chromosome+position [pos]:
+matching on: rsid OR pos
+# finally, define relevant columns for the chosen matching approach
+# - for "rsid" define rsID column:
+rsID column: NAME OF THE RSID COLUMN
+# - for "pos" define chromosome and position columns:
+chromosome column: NAME OF THE CHROMOSOME COLUMN
+position column: NAME OF THE POSITION COLUMN
+```
+
+Other arguments (*--genetic, --prs-wm, and --out*) must still be supplied in the command line.  
+Be aware that tool won't check the correctness of the config and will just fail if a required argument is undefined.
+
+Example of a valid config for http://www.pgscatalog.org/score/PGS000255/:
+```yaml
+beta column: effect_weight
+effect allele column: effect_allele
+matching on: rsid
+rsID column: rsID
+```
 
 ### Conscious limitation
 If your plink data does not have at least 50% of the variants from the PGSCatalog file, the tool won't allow you to run the PRS calculation, as the resulting scores might be too unreliable.

--- a/apply-pgscatalog-prs.py
+++ b/apply-pgscatalog-prs.py
@@ -461,7 +461,7 @@ def printout(text):
     console.print(layout)
 
 
-def render():
+def init_render_area():
     # Divide the "screen" in to three parts
     layout.split(
         Layout(name="header", size=3),
@@ -489,7 +489,7 @@ def main(args):
     # TODO: logging won't work above this line
     global LOGFILE
     LOGFILE = open(output_prefix + ".logging", 'w')
-    render()
+    init_render_area()
     maybe_load_config(args.config)
     pgscatalog_df, plink_variants_df, processed_wm_text_file = load_data(plink_prefix, prs_wm_text_file)
     # TODO: reuse

--- a/apply-pgscatalog-prs.py
+++ b/apply-pgscatalog-prs.py
@@ -360,8 +360,8 @@ def preprocess_data(pgscatalog_df, plink_variants_df, processed_wm_text_file):
         processed_wm_text_file, sep="\t", float_format="%.4e", index=False,
     )
     if not was_match_successful:
-        print("ERROR: Less that a half of the PGSCatalog SNPs are available.")
-        print("ERROR: This may be for one of the following reasons:")
+        printout("ERROR: Less that a half of the PGSCatalog SNPs are available.")
+        printout("ERROR: This may be for one of the following reasons:")
         print_error_files()
         exit(40)
 
@@ -394,8 +394,8 @@ def final_check(pgscatalog_df, plink_variants_df):
         console.print(layout)
         printout("-----------------")
     else:
-        print("You have decided to halt the execution due to the mismatch between the IDs in two files.")
-        print("Please, review this troubleshooting guide, if you need an inspiration about how fixing this:")
+        printout("You have decided to halt the execution due to the mismatch between the IDs in two files.")
+        printout("Please, review this troubleshooting guide, if you need an inspiration about how fixing this:")
         print_error_files()
         exit(50)
 
@@ -428,8 +428,8 @@ def calculate_prs(plink_prefix: str, processed_wm_text_file: str, output_prefix:
         "--out", output_prefix,
     ], universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     if process.returncode != 0 or not os.path.isfile(plink_output_file):
-        print("ERROR: plink has failed")
-        print(process.stderr)
+        printout("ERROR: plink has failed")
+        printout(process.stderr)
         exit(20)
 
     # Parsing plink results

--- a/apply-pgscatalog-prs.py
+++ b/apply-pgscatalog-prs.py
@@ -235,6 +235,8 @@ def check_the_files_match(pgscatalog_df, plink_variants_df):
     amount_of_shared_keys = len(set(plink_variants_df[PLINK_KEY_COLUMN]).intersection(pgscatalog_df[PGSCATALOG_KEY_COLUMN]))
     amount_of_plink_variants = plink_variants_df.shape[0]
     amount_of_pgscatalog_variants = pgscatalog_df.shape[0]
+    # TODO: maybe (!) test whether the *strongest* SNPs are present in the genetic data
+    # TODO: to ensure that PRS won't lose it's power?
     if amount_of_shared_keys > 0.50 * amount_of_pgscatalog_variants:
         printout(f"{amount_of_shared_keys} ({amount_of_shared_keys / amount_of_pgscatalog_variants:.0%}) "
                  f"variants from PGSCatalog are available in your plink data ({amount_of_plink_variants} variants)")

--- a/apply-pgscatalog-prs.py
+++ b/apply-pgscatalog-prs.py
@@ -3,6 +3,8 @@
 # diff /home/mvn373/fast/prs-repo/pre-calculated/scores/tool/olink000217-TARGETold.prs /home/mvn373/fast/prs-repo/pre-calculated/scores/tool/dev-test.prs
 # TODO: make support of ORs
 import argparse
+from io import TextIOWrapper
+import logging
 import time
 import os
 import shutil
@@ -38,6 +40,7 @@ console = Console()
 layout = Layout()
 live = Live(console=console)
 CONFIG: Union[None, dict] = None
+LOGFILE: Union[None, TextIOWrapper] = None
 
 
 PLINK_KEY_COLUMN = "rsid"
@@ -445,6 +448,10 @@ def calculate_prs(plink_prefix: str, processed_wm_text_file: str, output_prefix:
 
 
 def printout(text):
+    # Logging
+    if LOGFILE is not None:
+        LOGFILE.write(text+"\n")
+    # Printing to interactive console
     # noinspection PyUnresolvedReferences
     old_text = layout["main"].renderable.renderable
     old_lines = old_text.split("\n")
@@ -479,6 +486,9 @@ def render():
 def main(args):
     check_input(args)
     plink_prefix, prs_wm_text_file, output_prefix = args.genetic, args.prs_wm, args.out
+    # TODO: logging won't work above this line
+    global LOGFILE
+    LOGFILE = open(output_prefix + ".logging", 'w')
     render()
     maybe_load_config(args.config)
     pgscatalog_df, plink_variants_df, processed_wm_text_file = load_data(plink_prefix, prs_wm_text_file)
@@ -491,6 +501,7 @@ def main(args):
     preprocess_data(pgscatalog_df, plink_variants_df, processed_wm_text_file)
     final_check(pgscatalog_df, plink_variants_df)
     calculate_prs(plink_prefix, processed_wm_text_file, output_prefix)
+    LOGFILE.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Now it is possible to run the tool in the automated mode by providing answers to the questions that would have been asked in the interactive ("standard") mode in a yaml config. To make sure that history will be preserved in that case, a {--out}.logging file will also be produced, logging the tool execution. Logging will be done for all modes, because it is always a good idea, and there is no reason not to use it in the interactive mode.